### PR TITLE
Added common content for use with devdocs.

### DIFF
--- a/rst/export_env_vars.rst
+++ b/rst/export_env_vars.rst
@@ -1,0 +1,29 @@
+.. _export-env-var:
+
+Exporting environment variables
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To run the cURL requests shown in this guide, export your tenant ID and the token that you 
+got during authentication to environment variables. Then copy the examples from this guide 
+to the command line, script, or tool of your choice, changing URI parameters or body 
+parameters as needed.
+
+To export environment variables:
+
+1. Export your tenant ID to the ``account`` environment variable:
+
+   .. code::  
+
+       $ export account="tenantID"
+
+   Where ``tenantID`` is your account ID.
+
+2. Export your authentication token to the ``token`` environment
+   variable:
+
+   .. code::  
+
+       $ export token="token_id"
+
+   Where ``token_id`` is the authentication token value in the ``id`` field of the 
+   ``token`` element in the authentication response.

--- a/rst/how-curl-commands-work.rst
+++ b/rst/how-curl-commands-work.rst
@@ -1,0 +1,113 @@
+.. _how-curl-commands-work:
+
+How cURL commands work
+~~~~~~~~~~~~~~~~~~~~~~
+
+cURL is a command-line tool that you can use to interact with REST interfaces. cURL lets
+you to transmit and receive HTTP requests and responses from the command line or a shell
+script, which enables you to work with the API directly. It is available for Linux 
+distributions, Mac OS X, and Windows. For information about cURL, see 
+`http://curl.haxx.se/ <http://curl.haxx.se/>`__.
+
+To run the cURL request examples shown in this guide, copy each example from the HTML version
+of this guide directly to the command line or a script.
+
+.. _cn-dg-generalapi-curl-json:
+
+The following command is an example cURL command that provisions a server with an isolated
+network using JSON.
+
+**cURL command example: JSON request**
+
+.. code::
+
+        $ curl https://dfw.servers.api.rackspacecloud.com/v2/$account/servers \
+           -X POST \
+           -H "X-Auth-Project-Id: $account" \
+           -H "Content-Type: application/json" \
+           -H "Accept: application/json" \
+           -H "X-Auth-Token: $token" \
+           -d '{"server": {"name": "my_server_with_network", "imageRef": "d42f821e-c2d1-4796-9f07-af5ed7912d0e", "flavorRef": "2", "max_count": 1, "min_count": 1, "networks": [{"uuid": "538a112a-34d1-47ff-bf1e-c40639e886e2"}, {"uuid": "00000000-0000-0000-0000-000000000000"}, {"uuid": "11111111-1111-1111-1111-111111111111"}]}}' \
+          | python -m json.tool
+
+..  note::
+
+    The carriage returns in the cURL request examples use a backslash (``\``) as an escape
+    character. The escape character allows continuation of the command across multiple lines.
+
+The cURL examples in this guide use the following command-line options.
+
++-----------+-----------------------------------------------------------------------+
+| Option    | Description                                                           |
++===========+=======================================================================+
+| **-d**    | Sends the specified data in a **POST** request to the HTTP server.    |
+|           | Use this option to send a JSON request body to the server.            |
++-----------+-----------------------------------------------------------------------+
+| **-H**    | Specifies an extra HTTP header in the request. You can specify any    |
+|           | number of extra headers. Precede each header with the ``-H`` option.  |
+|           |                                                                       |
+|           | Common headers in Rackspace API requests are as follows:              |
+|           |                                                                       |
+|           |                                                                       |
+|           | ``Content-Type``: Required for operations with a request body.        |
+|           |                                                                       |
+|           | - Specifies the format of the request body. Following is the syntax   |
+|           |   for the header where format is ``json``:                            |
+|           |                                                                       |
+|           |   .. code::                                                           |
+|           |                                                                       |
+|           |      Content-Type: application/json                                   |
+|           |                                                                       |
+|           | ``X-Auth-Token``: Required.                                           |
+|           |                                                                       |
+|           | - Specifies the authentication token.                                 |
+|           |                                                                       |
+|           | ``X-Auth-Project-Id``: Optional.                                      |
+|           |                                                                       |
+|           | - Specifies the project ID, which can be your account number or       |
+|           |   another value.                                                      |
+|           |                                                                       |
+|           | ``Accept``: Optional.                                                 |
+|           |                                                                       |
+|           | - Specifies the format of the response body. Following is the syntax  |
+|           |   for the header where the format is ``json``, which is the           |
+|           |   default:                                                            |
+|           |                                                                       |
+|           |   .. code::                                                           |
+|           |                                                                       |
+|           |      Accept: application/json                                         |
+|           |                                                                       |
+|           |                                                                       |
++-----------+-----------------------------------------------------------------------+
+| **-i**    | Includes the HTTP header in the output.                               |
++-----------+-----------------------------------------------------------------------+
+| **-s**    | Specifies silent or quiet mode, which makes cURL mute. No progress or |
+|           | error messages are shown.                                             |
++-----------+-----------------------------------------------------------------------+
+| **-T**    | Transfers the specified local file to the remote URL.                 |
++-----------+-----------------------------------------------------------------------+
+| **-X**    | Specifies the request method to use when communicating with the HTTP  |
+|           | server. The specified request is used instead of the default method,  |
+|           | which is **GET**.                                                     |
++-----------+-----------------------------------------------------------------------+
+
+
+For commands that return a response, use json.tool to pretty-print the output by
+appending the following command to the cURL call:
+
+.. code::
+
+   | python -m json.tool
+
+..  note::
+
+    To use json.tool, import the JSON module. For information about json.tool, see
+    `JSON encoder and decoder`_.
+
+    If you run a Python version earlier than 2.6, import the simplejson module and use
+    simplejson.tool. For information about simplejson.tool, see `simplejson encoder and decoder`_.
+
+    If you do not want to pretty-print JSON output, omit this code.
+
+.. _json encoder and decoder: http://docs.python.org/2/library/json.html
+.. _simplejson encoder and decoder: http://simplejson.googlecode.com/svn/tags/simplejson-2.0.9/docs/index.html

--- a/rst/request-response.rst
+++ b/rst/request-response.rst
@@ -1,0 +1,49 @@
+.. _send-request-receive-responses:
+
+API requests and responses
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You have several options for sending requests through an API:
+
+- Developers and testers might prefer to use cURL with the command-line tool from
+  http://curl.haxx.se/.
+
+  For more information about using cURL, search for "cURL commands".
+
+- If you like to use a more graphical interface, the REST client for Mozilla Firefox also
+  works well for testing and trying out commands. See
+  https://addons.mozilla.org/en-US/firefox/addon/restclient/.
+
+  Similar browser plug-ins are available for browsers other than Firefox.
+
+   .. note::
+      If you use a browser plug-in, be sure to include the Header elements for ``Content-Type``
+      and ``X-Auth-Token`` with appropriate values.
+
+- You can download and install RESTclient, a Java application for testing ReSTful web
+  services, from http://code.google.com/p/rest-client/.
+
+.. _media-types:
+
+Media Types
+~~~~~~~~~~~
+
+The Cloud Images API accepts and serves JSON-encoded data. The media type required in the
+request varies by the following request types:
+
+- Requests that send **JSON-encoded data** use the following media type in their
+  ``Content-Type header: 'application/json'``.
+
+- Requests that use **HTTP PATCH syntax** use the following media type in their
+  ``Content-Type header: 'application/openstack-images-v2.1-json-patch'``.
+
+
+.. _json-schemas:
+
+JSON Schemas
+~~~~~~~~~~~~
+
+The necessary JSON-schema documents are provided at predictable URIs. A consumer
+validates server responses and client requests based on the published schemas. The
+schemas contained in this document are only examples and should not be used to validate
+your requests. A client should always fetch current schemas from the server.

--- a/rst/service-access-endpoints.rst
+++ b/rst/service-access-endpoints.rst
@@ -1,0 +1,33 @@
+.. _service-access-endpoints:
+
+Service access endpoints
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+The |product name| service is a regionalized service. The user of the service is 
+therefore responsible for selecting the appropriate regional endpoint to ensure access to 
+servers, networks, or other Cloud services.
+
+.. tip:: To help you decide which regionalized endpoint to use, read about
+   :kc-article:`special considerations<about-regions>` for choosing a data center.
+
+If you are working with cloud services that are in one of the Rackspace data centers, using 
+the ServiceNet endpoint in the same data center has no network costs and provides a faster 
+connection. ServiceNet is the data center internet network. In your authentication response 
+service catalog, it is listed as InternalURL. If you are working with services that are not 
+in one of the Rackspace data centers, you must use a public endpoint to connect. In your 
+authentication response, public endpoints are listed as publicURL. If you are working with 
+services in multiple data centers or have a mixed environment where you have services both 
+in your data centers and in Rackspace data centers, use a public endpoint because it is 
+accessible from all the servers in the different environments.
+
+.. note::
+   You should copy the base URLs directly from the catalog rather than trying to construct 
+   them manually.
+
+   Rackspace Cloud Identity returns a service catalog, which includes regional endpoints 
+   with your account ID. Your account ID, also known as project ID or tenant ID, refers to 
+   your Rackspace account number.
+
+.. tip::
+   If you do not know your account ID or which data center you are working in, you can find 
+   that information in your :mycloud:`Cloud Control Panel<>`.


### PR DESCRIPTION
4 files now available for cut and paste use with devdocs.  note: make sure your conf.py includes (with your product name):
rst_epilog = """
.. |apiservice| replace:: Rackspace Cloud Big Data API
.. |no changes| replace:: None for this release
.. |contract version| replace:: 1.0
.. |product name| replace:: Rackspace Cloud Big Data
"""