### PR TITLE
Create a true template for API operation reference topics 

### DIFF
--- a/api-guide-template/api-reference/methods/http-request-documentation-guidelines.rst
+++ b/api-guide-template/api-reference/methods/http-request-documentation-guidelines.rst
@@ -1,15 +1,15 @@
 HTTP request documentation guidelines
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-This section provides guidelines for documenting a single HTTP
+This document provides guidelines for documenting a single HTTP
 request (for example, ``GET /v2.0/servers``). It provides the topic
 structure and guidelines for content and style within each section.
 
 .. note::
 
-     Headings in parentheses indicate parts of the section that do not have a
+     Headings in parentheses indicate parts of a section that do not have a
      heading in the template. For an example of the template with content that
-     following these guidelines, see
+     follows these guidelines, see
      :ref:`Example http request topic <update-an-image>`.
 
 Title
@@ -66,9 +66,9 @@ Follow the URI code block with a description (no heading). Start with "This
 operation …"
 
 Include only necessary information that applies to the operation as a whole.
-Specific information about a parameter should go in the parameter table. If
-there  is more parameter information than can be shown in the table, place it
-in a  "parameter details" section following the introduction.
+Specific information about a parameter should go in the parameter table.
+However, if there is more parameter information than can be shown in the
+table, place it after the introduction.
 
 (parameter details)
 -------------------

--- a/api-guide-template/api-reference/methods/http-request-documentation-guidelines.rst
+++ b/api-guide-template/api-reference/methods/http-request-documentation-guidelines.rst
@@ -87,7 +87,7 @@ This is the first main section and heading after the title. Use the title
 
 This section includes tables for header, URI, query, and request body
 parameters, as needed. Precede each table with a basic introduction, such as
-"The request has the following ___ parameters."
+"The request has the following ___ parameters." Use the `list-table` directive to create the table.
 
 Parameter tables include the following columns:
 
@@ -138,7 +138,7 @@ Response parameters
 If you need to say something specific about the response, say it in this
 section, and then include a table for body parameters, as needed. Precede the
 table with a basic introduction, such as "The response has the following body
-parameters."
+parameters." Use the `list-table` directive to create the table.
 
 Parameter tables include the following columns:
 
@@ -181,8 +181,7 @@ introductory sentence.
 Response codes
 --------------
 
-Provide a table with the possible response codes for the operation. Introduce
-it as follows: "This operation can have the following response codes."
+Provide a table (using the `list-table` directive) with the possible response codes for the operation. Introduce it as follows: "This operation can have the following response codes."
 
 Response code tables include the following columns:
 

--- a/api-guide-template/api-reference/methods/http-request-documentation-guidelines.rst
+++ b/api-guide-template/api-reference/methods/http-request-documentation-guidelines.rst
@@ -87,7 +87,8 @@ This is the first main section and heading after the title. Use the title
 
 This section includes tables for header, URI, query, and request body
 parameters, as needed. Precede each table with a basic introduction, such as
-"The request has the following ___ parameters." Use the `list-table` directive to create the table.
+"The request has the following ___ parameters." Use the `list-table` directive
+to create the table.
 
 Parameter tables include the following columns:
 
@@ -98,8 +99,8 @@ Parameter tables include the following columns:
 - **Type**: Use the full word, with initial an capital. For example:
   String, Boolean
 
-- **Description**: If the parameter is required, start the description with *(Required)*.
-  Provide meaningful information about the parameter; don't
+- **Description**: If the parameter is required, start the description with
+  *(Required)*. Provide meaningful information about the parameter; don't
   just repeat the parameter’s name. Start the description with an initial
   phrase, punctuated and capitalized as a sentence. For example: "The unique
   identifier of the project." Follow the phrase with a sentence or two, as
@@ -181,7 +182,9 @@ introductory sentence.
 Response codes
 --------------
 
-Provide a table (using the `list-table` directive) with the possible response codes for the operation. Introduce it as follows: "This operation can have the following response codes."
+Provide a table (using the `list-table` directive) with the possible response
+codes for the operation. Introduce it as follows: "This operation can have the
+following response codes."
 
 Response code tables include the following columns:
 

--- a/api-guide-template/api-reference/methods/http-request-documentation-guidelines.rst
+++ b/api-guide-template/api-reference/methods/http-request-documentation-guidelines.rst
@@ -87,7 +87,8 @@ This is the first main section and heading after the title. Use the title
 
 This section includes tables for header, URI, query, and request body
 parameters, as needed. Precede each table with a basic introduction, such as
-"The request has the following ___ parameters." Use the `list-table` directive
+"The request has the following ___ parameters." Use the `list-table directive
+<http://docutils.sourceforge.net/docs/ref/rst/directives.html#list-table>`_
 to create the table.
 
 Parameter tables include the following columns:
@@ -139,7 +140,9 @@ Response parameters
 If you need to say something specific about the response, say it in this
 section, and then include a table for body parameters, as needed. Precede the
 table with a basic introduction, such as "The response has the following body
-parameters." Use the `list-table` directive to create the table.
+parameters." Use the `list-table directive
+<http://docutils.sourceforge.net/docs/ref/rst/directives.html#list-table>`_
+to create the table.
 
 Parameter tables include the following columns:
 
@@ -182,9 +185,10 @@ introductory sentence.
 Response codes
 --------------
 
-Provide a table (using the `list-table` directive) with the possible response
-codes for the operation. Introduce it as follows: "This operation can have the
-following response codes."
+Provide a table (using the `list-table directive
+<http://docutils.sourceforge.net/docs/ref/rst/directives.html#list-table>`_)
+with the possible response codes for the operation. Introduce it as follows:
+"This operation can have the following response codes."
 
 Response code tables include the following columns:
 

--- a/api-guide-template/api-reference/methods/http-request-template.rst
+++ b/api-guide-template/api-reference/methods/http-request-template.rst
@@ -3,30 +3,41 @@
 Document an HTTP request
 ========================
 
-.. This template provides the structure and some guidelines for documenting
-   a single HTTP request (for example, GET /v2.0/servers). For more instructions, see :ref:`HTTP request documentation guidelines <http-request-documentation-guidelines>`. For an example, see :ref:`Example HTTP request topic <update-an-image>`.
+   This template provides the structure, some guidelines, and example
+   content for documenting a single HTTP request (for example,
+   GET /v2.0/servers). For more guidelines, see 
+   :ref:`HTTP request documentation guidelines
+   <http-request-documentation-guidelines>`. For an extended example, 
+   see :ref:`Example HTTP request topic <update-an-image>`.
+   
+   Delete the example content and comments, and add your content.
 
 .. Immediately following the title, show the URI in a code block (no label).
-   For example:
 
 .. code::
 
-    PATCH /v1.0/images/{imageId}
+    METHOD /version/{projectId}/service/{placeholder}
 
-.. Follow the URI code block with a description (no heading). Start with
-   "This operation … ." Include only necessary information that applies to the operation as a whole. Specific information about a parameter should go in the parameter table, later in the file. If there is more parameter information than can be shown in the table, place it in a "Parameter details" section following the introduction.
+.. Immediately follow the URI code block with a description
+   (no heading). Include only necessary information that applies
+   to the operation as a whole. Place specific information about a
+   parameter in the parameter table, later in the file. If there is more
+   parameter information than can be shown in the table, place it after
+   the introduction.
 
    For example:
 
-This operation updates the specified image. You can update only an image that you own. You can use the HTTP PATCH method to update certain standard properties, and to add, update, or remove custom, user-defined image properties.
+This operation [describe what the operation does].
 
 Request parameters
 ~~~~~~~~~~~~~~~~~~
 
 .. This section includes tables for header, URI, query, and request
-   body parameters, as needed. Precede each table with a basic introduction, such as "The request has the following ___ parameters." For example:
+   body parameters, as needed. Precede each table with a basic
+   introduction, such as "The request has the following ___ parameters."
 
-The request has the following URI parameters.
+The request has the following [header | URI | query | request body]
+parameters.
 
 .. Parameter tables include the following columns: Name, Type, Description.
    Following is an example table, created with the `list-table` directive:
@@ -43,10 +54,6 @@ The request has the following URI parameters.
      - *(Required)* The operation to be executed: ``add``, ``remove``, or
        ``replace``. For more information about updating image properties, see
        the beginning of this operation section.
-   * - path
-     - String
-     - *(Required)* The location within the image where the operation is to be
-       performed.
    * - value
      - String
      - The actual value to be added or replaced. This parameter is not required
@@ -59,10 +66,12 @@ Request example
 ~~~~~~~~~~~~~~~
 
 .. This section contains the code example with an introductory sentence,
-   such as "The following example shows the JSON request for retrieving a list of flavors." Specify the type of request, if applicable (such as JSON, HTTP, or cURL). In the example, include the HTTP request header and show the body (if there is a body). For example:
+   such as "The following example shows the JSON request for retrieving a list
+   of flavors." Specify the type of request, if applicable (such as JSON,
+   HTTP, or cURL). In the example, include the HTTP request header and show
+   the body (if there is a body). For example:
 
-The following example updates two properties for the image: `name` and
-`tags`.
+The following example shows [describe what the example shows].
 
 .. code::
 
@@ -81,7 +90,11 @@ Response parameters
 ~~~~~~~~~~~~~~~~~~~
 
 .. If you need to say something specific about the response, say it in
-   this section, and then include a table for body parameters, as needed (using the `list-table` directive). Precede the table with a basic introduction, such as "The response has the following body parameters." Parameter tables include the following columns: Name, Type, Description. For example:
+   this section, and then include a table for body parameters, as needed
+   (using the `list-table` directive). Precede the table with a basic
+   introduction, such as "The response has the following body parameters."
+   Parameter tables include the following columns: Name, Type, Description.
+   Following is an example table, created with the `list-table` directive:
 
 The response has the following body parameters.
 
@@ -101,42 +114,17 @@ The response has the following body parameters.
    * - status
      - String
      - The status of the image.
-   * - visibility
-     - String
-     - Specifies image visibility as ``public``, ``private``, or ``shared``.
-   * - checksum
-     - String
-     - The checksum of the image.
-   * - minRam
-     - String
-     - The minimum server RAM required for this image.
-   * - minDisk
-     - String
-     - The minimum server disk size required for this image.
-   * - tags[ ]
-     - Array
-     - An array of user-defined image tags.
-   * - created_at
-     - String
-     - The date and time that the image was created.
-   * - updated_at
-     - String
-     - The date and time that the image was updated.
-   * - schema
-     - String
-     - The schema of the image.
 
 Response example
 ~~~~~~~~~~~~~~~~
 
 .. This section contains the code example with an introductory sentence,
-   such as "The following example shows the JSON response for the request." Specify the type of response, if applicable (such as JSON, HTTP, or cURL). In the example, include the HTTP request header and show the body (if there is a body). For example:
+   such as "The following example shows the JSON response for the request."
+   Specify the type of response, if applicable (such as JSON, HTTP, or cURL).
+   In the example, include the HTTP request header and show the body (if there
+   is a body). For example:
 
-You can show multiple examples, by error code. Precede each with an
-introductory sentence.
-
-The following example shows the JSON response for retrieving the backup for a
-project.
+The following example shows [describe what the example shows].
 
 .. code::
 
@@ -157,7 +145,9 @@ Response codes
 ~~~~~~~~~~~~~~
 
 .. Provide a `list-table` table with the possible response codes for
-   the operation. Introduce it as follows: "This operation can have the following response codes." Response code tables include the following columns: Code, Name, Description. For example:
+   the operation. Response code tables include the following columns:
+   Code, Name, Description. Following is an example table with just a
+   few possible codes.
 
 This operation can have the following response codes.
 
@@ -182,23 +172,3 @@ This operation can have the following response codes.
    * - 403
      - Forbidden
      - The server understood the request but is not authorizing it.
-   * - 405
-     - Method Not Allowed
-     - The method received in the request line is known by the origin server
-       but is not supported by the target resource.
-   * - 413
-     - Over Limit
-     - The number of items returned is above the allowed limit.
-   * - 415
-     - Bad Media Type
-     - This error might result if the wrong media type is used in the cURL
-       request.
-   * - 500
-     - API Fault
-     - The server encountered an unexpected condition that prevented it from
-       fulfilling the request.
-   * - 503
-     - Service Unavailable
-     - The server is currently unable to handle the request because of a
-       temporary overload or scheduled maintenance, which will likely be
-       alleviated after some delay.

--- a/api-guide-template/api-reference/methods/http-request-template.rst
+++ b/api-guide-template/api-reference/methods/http-request-template.rst
@@ -1,0 +1,204 @@
+
+========================
+Document an HTTP request
+========================
+
+.. This template provides the structure and some guidelines for documenting
+   a single HTTP request (for example, GET /v2.0/servers). For more instructions, see :ref:`HTTP request documentation guidelines <http-request-documentation-guidelines>`. For an example, see :ref:`Example HTTP request topic <update-an-image>`.
+
+.. Immediately following the title, show the URI in a code block (no label).
+   For example:
+
+.. code::
+
+    PATCH /v1.0/images/{imageId}
+
+.. Follow the URI code block with a description (no heading). Start with
+   "This operation … ." Include only necessary information that applies to the operation as a whole. Specific information about a parameter should go in the parameter table, later in the file. If there is more parameter information than can be shown in the table, place it in a "Parameter details" section following the introduction.
+
+   For example:
+
+This operation updates the specified image. You can update only an image that you own. You can use the HTTP PATCH method to update certain standard properties, and to add, update, or remove custom, user-defined image properties.
+
+Request parameters
+~~~~~~~~~~~~~~~~~~
+
+.. This section includes tables for header, URI, query, and request
+   body parameters, as needed. Precede each table with a basic introduction, such as "The request has the following ___ parameters." For example:
+
+The request has the following URI parameters.
+
+.. Parameter tables include the following columns: Name, Type, Description.
+   Following is an example table, created with the `list-table` directive:
+
+.. list-table::
+   :widths: 15 10 30
+   :header-rows: 1
+
+   * - Name
+     - Type
+     - Description
+   * - op
+     - String
+     - *(Required)* The operation to be executed: ``add``, ``remove``, or
+       ``replace``. For more information about updating image properties, see
+       the beginning of this operation section.
+   * - path
+     - String
+     - *(Required)* The location within the image where the operation is to be
+       performed.
+   * - value
+     - String
+     - The actual value to be added or replaced. This parameter is not required
+       for the ``remove`` operation.
+
+.. If there are no request body parameters, include the following
+   sentence: "This operation does not accept a request body."
+
+Request example
+~~~~~~~~~~~~~~~
+
+.. This section contains the code example with an introductory sentence,
+   such as "The following example shows the JSON request for retrieving a list of flavors." Specify the type of request, if applicable (such as JSON, HTTP, or cURL). In the example, include the HTTP request header and show the body (if there is a body). For example:
+
+The following example updates two properties for the image: `name` and
+`tags`.
+
+.. code::
+
+    X-Auth-Token: f064c46a782c444cb4ba4b6434288f7c
+    Content-Type: application/json
+    Accept: application/json
+
+.. code::
+
+    [
+        {"op": "replace", "path": "/name", "value": "Fedora 17"},
+        {"op": "replace", "path": "/tags", "value": ["fedora", "beefy"]}
+    ]
+
+Response parameters
+~~~~~~~~~~~~~~~~~~~
+
+.. If you need to say something specific about the response, say it in
+   this section, and then include a table for body parameters, as needed (using the `list-table` directive). Precede the table with a basic introduction, such as "The response has the following body parameters." Parameter tables include the following columns: Name, Type, Description. For example:
+
+The response has the following body parameters.
+
+.. list-table::
+   :widths: 15 10 30
+   :header-rows: 1
+
+   * - Name
+     - Type
+     - Description
+   * - id
+     - String
+     - The UUID of the image.
+   * - name
+     - String
+     - The name of the image.
+   * - status
+     - String
+     - The status of the image.
+   * - visibility
+     - String
+     - Specifies image visibility as ``public``, ``private``, or ``shared``.
+   * - checksum
+     - String
+     - The checksum of the image.
+   * - minRam
+     - String
+     - The minimum server RAM required for this image.
+   * - minDisk
+     - String
+     - The minimum server disk size required for this image.
+   * - tags[ ]
+     - Array
+     - An array of user-defined image tags.
+   * - created_at
+     - String
+     - The date and time that the image was created.
+   * - updated_at
+     - String
+     - The date and time that the image was updated.
+   * - schema
+     - String
+     - The schema of the image.
+
+Response example
+~~~~~~~~~~~~~~~~
+
+.. This section contains the code example with an introductory sentence,
+   such as "The following example shows the JSON response for the request." Specify the type of response, if applicable (such as JSON, HTTP, or cURL). In the example, include the HTTP request header and show the body (if there is a body). For example:
+
+You can show multiple examples, by error code. Precede each with an
+introductory sentence.
+
+The following example shows the JSON response for retrieving the backup for a
+project.
+
+.. code::
+
+    {
+      "id":"e7db3b45-8db7-47ad-8109-3fb55c2c24fd",
+      "name":"Fedora 17",
+      "status":"queued",
+      "visibility":"public",
+      "tags": ["fedora", "beefy"],
+      "created_at":"2012-08-11T17:15:52Z",
+      "updated_at":"2012-08-11T17:15:52Z",
+      "self":"/v2/images/e7db3b45-8db7-47ad-8109-3fb55c2c24fd",
+      "file":"/v2/images/e7db3b45-8db7-47ad-8109-3fb55c2c24fd/file",
+      "schema":"/v2/schemas/image"
+    }
+
+Response codes
+~~~~~~~~~~~~~~
+
+.. Provide a `list-table` table with the possible response codes for
+   the operation. Introduce it as follows: "This operation can have the following response codes." Response code tables include the following columns: Code, Name, Description. For example:
+
+This operation can have the following response codes.
+
+.. list-table::
+   :widths: 15 10 30
+   :header-rows: 1
+
+   * - Code
+     - Name
+     - Description
+   * - 200
+     - Success
+     - The request succeeded.
+   * - 400
+     - Error
+     - A general error has occurred.
+   * - 401
+     - Unauthorized
+     - The request has not been applied because it lacks valid authentication
+       credentials for the target resource. The credentials are either expired
+       or invalid.
+   * - 403
+     - Forbidden
+     - The server understood the request but is not authorizing it.
+   * - 405
+     - Method Not Allowed
+     - The method received in the request line is known by the origin server
+       but is not supported by the target resource.
+   * - 413
+     - Over Limit
+     - The number of items returned is above the allowed limit.
+   * - 415
+     - Bad Media Type
+     - This error might result if the wrong media type is used in the cURL
+       request.
+   * - 500
+     - API Fault
+     - The server encountered an unexpected condition that prevented it from
+       fulfilling the request.
+   * - 503
+     - Service Unavailable
+     - The server is currently unable to handle the request because of a
+       temporary overload or scheduled maintenance, which will likely be
+       alleviated after some delay.

--- a/api-guide-template/api-reference/methods/http-request-template.rst
+++ b/api-guide-template/api-reference/methods/http-request-template.rst
@@ -19,15 +19,23 @@ Follow the URI code block with a description. Include only information that
 applies to the operation as a whole. Place specific information about a
 parameter in the parameter table, later in the file. For example:
 
-This operation updates the specified image. You can update only an image that you own.
+This operation updates the specified image. You can update only an image that
+you own.
+
+.. note::
+
+      In all of the sections that follow, use the headings that are shown.
+      The only heading that should be customized is the main title of the
+      topic.
 
 Request parameters
 ~~~~~~~~~~~~~~~~~~
 
 Provide tables for header, URI, query, and request body parameters, as needed
-(using the ``list-table`` directive). Precede each table with a basic
-introduction. Parameter tables include the following columns: Name, Type,
-Description. For example:
+(using the `list-table directive
+<http://docutils.sourceforge.net/docs/ref/rst/directives.html#list-table>`_).
+Precede each table with a basic introduction. Parameter tables include the
+following columns: Name, Type, Description. For example:
 
 The request has the following body parameters:
 
@@ -79,9 +87,10 @@ Response parameters
 
 If you need to say something specific about the response, say it in this
 section, and then include a table for body parameters, as needed (using the
-``list-table`` directive). Precede the table with a basic introduction.
-Parameter tables include the following columns: Name, Type, Description. For
-example:
+`list-table directive
+<http://docutils.sourceforge.net/docs/ref/rst/directives.html#list-table>`_).
+Precede the table with a basic introduction. Parameter tables include the
+following columns: Name, Type, Description. For example:
 
 The response has the following body parameters:
 
@@ -129,9 +138,11 @@ The following example shows the JSON response for the request:
 Response codes
 ~~~~~~~~~~~~~~
 
-Provide a `list-table` table with the possible response codes for the
-operation. Response code tables include the following columns: Code, Name,
-Description. Following is an example table with just a few possible codes.
+Provide a `list table
+<http://docutils.sourceforge.net/docs/ref/rst/directives.html#list-table>`_
+with the possible response codes for the operation. Response code tables
+include the following columns: Code, Name, Description. Following is an
+example table with just a few possible codes.
 
 This operation can have the following response codes:
 

--- a/api-guide-template/api-reference/methods/http-request-template.rst
+++ b/api-guide-template/api-reference/methods/http-request-template.rst
@@ -12,35 +12,33 @@ Document an HTTP request
    
    Delete the example content and comments, and add your content.
 
-.. Immediately following the title, show the URI in a code block (no label).
+.. Following the title, show the URI in a code block (no label).
 
 .. code::
 
     METHOD /version/{projectId}/service/{placeholder}
 
-.. Immediately follow the URI code block with a description
+.. Follow the URI code block with a description
    (no heading). Include only necessary information that applies
    to the operation as a whole. Place specific information about a
    parameter in the parameter table, later in the file. If there is more
    parameter information than can be shown in the table, place it after
    the introduction.
 
-   For example:
-
 This operation [describe what the operation does].
 
 Request parameters
 ~~~~~~~~~~~~~~~~~~
 
-.. This section includes tables for header, URI, query, and request
+.. Provide tables for header, URI, query, and request
    body parameters, as needed. Precede each table with a basic
-   introduction, such as "The request has the following ___ parameters."
+   introduction.
 
 The request has the following [header | URI | query | request body]
 parameters.
 
 .. Parameter tables include the following columns: Name, Type, Description.
-   Following is an example table, created with the `list-table` directive:
+   Following is an example table, created with the `list-table` directive.
 
 .. list-table::
    :widths: 15 10 30
@@ -65,11 +63,11 @@ parameters.
 Request example
 ~~~~~~~~~~~~~~~
 
-.. This section contains the code example with an introductory sentence,
+.. Provide a code example with an introductory sentence,
    such as "The following example shows the JSON request for retrieving a list
    of flavors." Specify the type of request, if applicable (such as JSON,
    HTTP, or cURL). In the example, include the HTTP request header and show
-   the body (if there is a body). For example:
+   the body (if there is a body).
 
 The following example shows [describe what the example shows].
 
@@ -92,11 +90,12 @@ Response parameters
 .. If you need to say something specific about the response, say it in
    this section, and then include a table for body parameters, as needed
    (using the `list-table` directive). Precede the table with a basic
-   introduction, such as "The response has the following body parameters."
-   Parameter tables include the following columns: Name, Type, Description.
-   Following is an example table, created with the `list-table` directive:
+   introduction.
 
 The response has the following body parameters.
+
+.. Parameter tables include the following columns: Name, Type, Description.
+   Following is an example table, created with the `list-table` directive.
 
 .. list-table::
    :widths: 15 10 30
@@ -118,11 +117,11 @@ The response has the following body parameters.
 Response example
 ~~~~~~~~~~~~~~~~
 
-.. This section contains the code example with an introductory sentence,
+.. Provide a code example with an introductory sentence,
    such as "The following example shows the JSON response for the request."
    Specify the type of response, if applicable (such as JSON, HTTP, or cURL).
    In the example, include the HTTP request header and show the body (if there
-   is a body). For example:
+   is a body).
 
 The following example shows [describe what the example shows].
 

--- a/api-guide-template/api-reference/methods/http-request-template.rst
+++ b/api-guide-template/api-reference/methods/http-request-template.rst
@@ -3,42 +3,33 @@
 Document an HTTP request
 ========================
 
-   This template provides the structure, some guidelines, and example
-   content for documenting a single HTTP request (for example,
-   GET /v2.0/servers). For more guidelines, see 
-   :ref:`HTTP request documentation guidelines
-   <http-request-documentation-guidelines>`. For an extended example, 
-   see :ref:`Example HTTP request topic <update-an-image>`.
+This template provides structure, guidelines, and example content for
+documenting a single HTTP request (for example, ``GET /v2.0/servers``). For
+more guidelines, see :ref:`HTTP request documentation guidelines
+<http-request-documentation-guidelines>`. For an extended example, see
+:ref:`Example HTTP request topic <update-an-image>`.
    
-   Delete the example content and comments, and add your content.
-
-.. Following the title, show the URI in a code block (no label).
+Following the title, show the URI in a code block (no label). For example:
 
 .. code::
 
-    METHOD /version/{projectId}/service/{placeholder}
+    PATCH /v1.0/images/{imageId}
 
-.. Follow the URI code block with a description
-   (no heading). Include only necessary information that applies
-   to the operation as a whole. Place specific information about a
-   parameter in the parameter table, later in the file. If there is more
-   parameter information than can be shown in the table, place it after
-   the introduction.
+Follow the URI code block with a description. Include only information that
+applies to the operation as a whole. Place specific information about a
+parameter in the parameter table, later in the file. For example:
 
-This operation [describe what the operation does].
+This operation updates the specified image. You can update only an image that you own.
 
 Request parameters
 ~~~~~~~~~~~~~~~~~~
 
-.. Provide tables for header, URI, query, and request
-   body parameters, as needed. Precede each table with a basic
-   introduction.
+Provide tables for header, URI, query, and request body parameters, as needed
+(using the ``list-table`` directive). Precede each table with a basic
+introduction. Parameter tables include the following columns: Name, Type,
+Description. For example:
 
-The request has the following [header | URI | query | request body]
-parameters.
-
-.. Parameter tables include the following columns: Name, Type, Description.
-   Following is an example table, created with the `list-table` directive.
+The request has the following body parameters:
 
 .. list-table::
    :widths: 15 10 30
@@ -57,19 +48,18 @@ parameters.
      - The actual value to be added or replaced. This parameter is not required
        for the ``remove`` operation.
 
-.. If there are no request body parameters, include the following
-   sentence: "This operation does not accept a request body."
+If there are no request body parameters, include the following sentence:
+
+This operation does not accept a request body.
 
 Request example
 ~~~~~~~~~~~~~~~
 
-.. Provide a code example with an introductory sentence,
-   such as "The following example shows the JSON request for retrieving a list
-   of flavors." Specify the type of request, if applicable (such as JSON,
-   HTTP, or cURL). In the example, include the HTTP request header and show
-   the body (if there is a body).
+Provide a request example with an introductory sentence. Specify the type of
+request, if applicable (such as JSON, HTTP, or cURL). In the example, include
+the HTTP request header and show the body (if there is a body). For example:
 
-The following example shows [describe what the example shows].
+The following example shows the JSON request for retrieving a list of flavors:
 
 .. code::
 
@@ -87,15 +77,13 @@ The following example shows [describe what the example shows].
 Response parameters
 ~~~~~~~~~~~~~~~~~~~
 
-.. If you need to say something specific about the response, say it in
-   this section, and then include a table for body parameters, as needed
-   (using the `list-table` directive). Precede the table with a basic
-   introduction.
+If you need to say something specific about the response, say it in this
+section, and then include a table for body parameters, as needed (using the
+``list-table`` directive). Precede the table with a basic introduction.
+Parameter tables include the following columns: Name, Type, Description. For
+example:
 
-The response has the following body parameters.
-
-.. Parameter tables include the following columns: Name, Type, Description.
-   Following is an example table, created with the `list-table` directive.
+The response has the following body parameters:
 
 .. list-table::
    :widths: 15 10 30
@@ -117,13 +105,11 @@ The response has the following body parameters.
 Response example
 ~~~~~~~~~~~~~~~~
 
-.. Provide a code example with an introductory sentence,
-   such as "The following example shows the JSON response for the request."
-   Specify the type of response, if applicable (such as JSON, HTTP, or cURL).
-   In the example, include the HTTP request header and show the body (if there
-   is a body).
+Provide a response example with an introductory sentence. Specify the type of
+response, if applicable (such as JSON, HTTP, or cURL). In the example, include
+the HTTP request header and show the body (if there is a body). For example:
 
-The following example shows [describe what the example shows].
+The following example shows the JSON response for the request:
 
 .. code::
 
@@ -143,12 +129,11 @@ The following example shows [describe what the example shows].
 Response codes
 ~~~~~~~~~~~~~~
 
-.. Provide a `list-table` table with the possible response codes for
-   the operation. Response code tables include the following columns:
-   Code, Name, Description. Following is an example table with just a
-   few possible codes.
+Provide a `list-table` table with the possible response codes for the
+operation. Response code tables include the following columns: Code, Name,
+Description. Following is an example table with just a few possible codes.
 
-This operation can have the following response codes.
+This operation can have the following response codes:
 
 .. list-table::
    :widths: 15 10 30


### PR DESCRIPTION
I basically merged the existing guidelines and example to create a template file that users can copy and use to create an API operation topic. The instructions are abbreviated and placed in comments (visible in Raw or editing mode); the example text is provided as boilerplate or as short example text. The top instruction is provided as a block quote, so that it is visible when a person looks at the file in GitHub but is obviously not boilerplate text. 

I'm interested to know what people think of using this method to create a template. Are there too many instructions? Should the boilerplate (such as it is) and examples look like this, or different? All comments welcome. 

BTW: I also updated the guidelines doc to tell users to use the `list-table` directive. Maybe I should have done that in a different PR. . .    